### PR TITLE
update: specify docker image platform

### DIFF
--- a/copilot/alertmanager/manifest.yml
+++ b/copilot/alertmanager/manifest.yml
@@ -12,7 +12,7 @@ image:
 # Service in the cluster settings
 cpu: 256     # 256 means 0.25 vCPU.
 memory: 512  # Amount in MiB.
-platform: linux/x86=64
+platform: linux/x86_64
 count: 1     # Number of tasks that should be running in your service.
 exec: true   # Enable running commands in your container.
 

--- a/copilot/alertmanager/manifest.yml
+++ b/copilot/alertmanager/manifest.yml
@@ -12,6 +12,7 @@ image:
 # Service in the cluster settings
 cpu: 256     # 256 means 0.25 vCPU.
 memory: 512  # Amount in MiB.
+platform: linux/x86=64
 count: 1     # Number of tasks that should be running in your service.
 exec: true   # Enable running commands in your container.
 

--- a/copilot/blackbox-exporter-with-eip/manifest.yml
+++ b/copilot/blackbox-exporter-with-eip/manifest.yml
@@ -12,7 +12,7 @@ image:
 # Service in the cluster settings
 cpu: 256     # 256 means 0.25 vCPU.
 memory: 512  # Amount in MiB.
-platform: linux/x86=64
+platform: linux/x86_64
 count: 1     # Number of tasks that should be running in your service.
 exec: true   # Enable running commands in your container.
 

--- a/copilot/blackbox-exporter-with-eip/manifest.yml
+++ b/copilot/blackbox-exporter-with-eip/manifest.yml
@@ -12,6 +12,7 @@ image:
 # Service in the cluster settings
 cpu: 256     # 256 means 0.25 vCPU.
 memory: 512  # Amount in MiB.
+platform: linux/x86=64
 count: 1     # Number of tasks that should be running in your service.
 exec: true   # Enable running commands in your container.
 

--- a/copilot/blackbox-exporter/manifest.yml
+++ b/copilot/blackbox-exporter/manifest.yml
@@ -12,6 +12,6 @@ image:
 # Service in the cluster settings
 cpu: 256     # 256 means 0.25 vCPU.
 memory: 512  # Amount in MiB.
-platform: linux/x86=64
+platform: linux/x86_64
 count: 1     # Number of tasks that should be running in your service.
 exec: true   # Enable running commands in your container.

--- a/copilot/blackbox-exporter/manifest.yml
+++ b/copilot/blackbox-exporter/manifest.yml
@@ -12,5 +12,6 @@ image:
 # Service in the cluster settings
 cpu: 256     # 256 means 0.25 vCPU.
 memory: 512  # Amount in MiB.
+platform: linux/x86=64
 count: 1     # Number of tasks that should be running in your service.
 exec: true   # Enable running commands in your container.

--- a/copilot/prometheus/manifest.yml
+++ b/copilot/prometheus/manifest.yml
@@ -21,6 +21,6 @@ image:
 # Service in the cluster settings
 cpu: 256     # 256 means 0.25 vCPU.
 memory: 512  # Amount in MiB.
-platform: linux/x86=64
+platform: linux/x86_64
 count: 1     # Number of tasks that should be running in your service.
 exec: true   # Enable running commands in your container.

--- a/copilot/prometheus/manifest.yml
+++ b/copilot/prometheus/manifest.yml
@@ -21,5 +21,6 @@ image:
 # Service in the cluster settings
 cpu: 256     # 256 means 0.25 vCPU.
 memory: 512  # Amount in MiB.
+platform: linux/x86=64
 count: 1     # Number of tasks that should be running in your service.
 exec: true   # Enable running commands in your container.


### PR DESCRIPTION
See https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#platform

- Fix docker image platform when docker build

For example, when you use M1 Mac which has arm architecture, docker images you build naively cannot be used in Fargate because Fargate cannot only start images built for arm architecture.

In this PR, we specify the image platform.